### PR TITLE
Add quick benchmark

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -838,7 +838,14 @@ module ActiveRecord
 
     def preload_associations(records) # :nodoc:
       preload = preload_values
-      preload += eager_loading? ? includes_values_non_referenced : includes_values
+      if ENV["SLIM_PATCH"].present?
+        preload += eager_loading? ? includes_values_non_referenced : includes_values
+      elsif ENV["SLIM_PATCH_CODE_ONLY"].present?
+        includes_values_non_referenced
+        preload += includes_values unless eager_loading?
+      else
+        preload += includes_values unless eager_loading?
+      end
       scope = strict_loading_value ? StrictLoadingScope : nil
       preload.each do |associations|
         ActiveRecord::Associations::Preloader.new(records: records, associations: associations, scope: scope).call

--- a/activerecord/test/cases/associations/performance_test.rb
+++ b/activerecord/test/cases/associations/performance_test.rb
@@ -84,7 +84,7 @@ class AssociationsPerformanceTest < ActiveRecord::TestCase
       authors.to_sql
     end
 
-    assert_slower_by_at_most 0.8, baseline: baseline, duration: DURATION do
+    assert_slower_by_at_most 0.7, baseline: baseline, duration: DURATION do
       ENV["SLIM_PATCH_CODE_ONLY"] = nil
       ENV["SLIM_PATCH"] = "true"
       authors = Author.includes(

--- a/activerecord/test/cases/associations/performance_test.rb
+++ b/activerecord/test/cases/associations/performance_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "cases/encryption/helper"
+require "models/author"
+require "models/book"
+require "models/citation"
+require "models/reader"
+require "models/post"
+require "models/reference"
+require "models/comment"
+require "models/rating"
+require "models/category"
+require "models/categorization"
+require "models/tag"
+require "models/tagging"
+require "models/person"
+require "models/club"
+require "models/developer"
+require "models/project"
+require "models/computer"
+require "models/company"
+require "models/contract"
+require "models/member"
+require "models/membership"
+require "models/sponsor"
+
+class AssociationsPerformanceTest < ActiveRecord::TestCase
+  include ActiveRecord::Encryption::PerformanceHelpers
+
+  fixtures :authors, :books, :citations, :readers, :posts, :references, :comments, :ratings,
+    :categories, :categorizations, :tags, :taggings, :people, :clubs, :members, :memberships,
+    :sponsors, :developers, :projects, :developers_projects, :computers, :companies, :accounts
+
+  DURATION = 10
+
+  def test_performance_tree_code_only
+    baseline = lambda do
+      ENV["SLIM_PATCH_CODE_ONLY"] = nil
+      ENV["SLIM_PATCH"] = nil
+      authors = Author.includes(
+        :books, { posts: :special_comments }, { categorizations: :category }
+      ).order("comments.body").where("posts.id = 4")
+      authors.to_a
+    end
+
+    assert_slower_by_at_most 1.05, baseline: baseline, duration: DURATION do
+      ENV["SLIM_PATCH_CODE_ONLY"] = "true"
+      ENV["SLIM_PATCH"] = nil
+      authors = Author.includes(
+        :books, { posts: :special_comments }, { categorizations: :category }
+      ).order("comments.body").where("posts.id = 4")
+      authors.to_a
+    end
+  end
+
+  def test_performance
+    baseline = lambda do
+      ENV["SLIM_PATCH_CODE_ONLY"] = nil
+      ENV["SLIM_PATCH"] = nil
+      authors = Author.includes(
+        :books, { posts: :special_comments }, { categorizations: :category }
+      ).order("comments.body").where("posts.id = 4")
+      authors.to_a
+    end
+
+    assert_slower_by_at_most 1.2, baseline: baseline, duration: DURATION do
+      ENV["SLIM_PATCH_CODE_ONLY"] = nil
+      ENV["SLIM_PATCH"] = "true"
+      authors = Author.includes(
+        :books, { posts: :special_comments }, { categorizations: :category }
+      ).order("comments.body").where("posts.id = 4")
+      authors.to_a
+    end
+  end
+end


### PR DESCRIPTION
Result:
```sh
Using sqlite3
Run options: --seed 1477

# Running:

Warming up --------------------------------------
                Code    51.000  i/100ms
            Baseline    55.000  i/100ms
Calculating -------------------------------------
                Code    485.488  (± 4.7%) i/s -      4.845k in  10.002550s
            Baseline    512.926  (± 3.3%) i/s -      5.170k in  10.090562s

Comparison:
            Baseline:      512.9 i/s
                Code:      485.5 i/s - same-ish: difference falls within error

F

Failure:
AssociationsPerformanceTest#test_performance_tree_code_only [/home/ardecvz/dev/rails/activerecord/test/cases/associations/performance_test.rb:47]:
Expecting 1.05 times slower at most, but got 1.0565176525729307 times slower


bin/test test/cases/associations/performance_test.rb:37

Warming up --------------------------------------
                Code    37.000  i/100ms
            Baseline    55.000  i/100ms
Calculating -------------------------------------
                Code    396.518  (± 3.0%) i/s -      3.996k in  10.086650s
            Baseline    496.981  (± 6.0%) i/s -      5.005k in  10.110700s

Comparison:
            Baseline:      497.0 i/s
                Code:      396.5 i/s - 1.25x  (± 0.00) slower

F

Failure:
AssociationsPerformanceTest#test_performance_objects_allocating [/home/ardecvz/dev/rails/activerecord/test/cases/associations/performance_test.rb:67]:
Expecting 1.2 times slower at most, but got 1.2533632086343738 times slower


bin/test test/cases/associations/performance_test.rb:57



Finished in 48.031965s, 0.0416 runs/s, 0.0416 assertions/s.
2 runs, 2 assertions, 2 failures, 0 errors, 0 skips
```
Win case:
```
Using sqlite3
Run options: --seed 59797

# Running:

Warming up --------------------------------------
                Code   195.000  i/100ms
            Baseline   133.000  i/100ms
Calculating -------------------------------------
                Code      1.969k (± 5.5%) i/s -     19.695k in  10.033527s
            Baseline      1.386k (± 2.7%) i/s -     13.965k in  10.086623s

Comparison:
                Code:     1969.3 i/s
            Baseline:     1385.6 i/s - 1.42x  (± 0.00) slower

F

Failure:
AssociationsPerformanceTest#test_performance_sql_only [/home/ardecvz/dev/rails/activerecord/test/cases/associations/performance_test.rb:87]:
Expecting 0.7 times slower at most, but got 0.7035809515047433 times slower


bin/test test/cases/associations/performance_test.rb:77



Finished in 25.678418s, 0.0389 runs/s, 0.0389 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```